### PR TITLE
Bugfix file staging

### DIFF
--- a/bin/workflow_glue/filter_metadata.py
+++ b/bin/workflow_glue/filter_metadata.py
@@ -1,3 +1,8 @@
+from fileinput import filename
+from pathlib import Path
+import glob
+import os
+
 from dominate.tags import figure, div, section, h2
 from dominate.util import raw
 import locale
@@ -221,18 +226,39 @@ def div_summary(titles):
     return html
 
 
-def add_qc(args, tables):
-    figs = sort_figures(args)
+def add_qc(plots_dir, tables):
+
+    plots_dir = Path(*plots_dir)
+
+    # Find all HTML files directly inside plots_dir
+    html_files = sorted(glob.glob(str(plots_dir / "*.html")))
+
+    if not html_files:
+        raise FileNotFoundError(f"No .html files found in: {plots_dir}")
+
+    figs = sort_figures(html_files)  # Reuse your existing sorting logic
+
     titles = [v[1] for v in figs.values()]
+
+    # Layout identical to your original function
     with div(style="display: flex"):
         with div(style="flex: 1"):
             raw(div_summary(titles))
+
         with div(style="flex: 4; overflow: auto"):
-            for i,f in enumerate(figs.values()):
-                with open(f[0], 'r', encoding="UTF-8") as html:
+            for i, f in enumerate(figs.values()):
+                # f[0] = html file, f[1] = title
+                html_file = f[0]
+                title = f[1]
+
+                # Read HTML file
+                with open(html_file, 'r', encoding="UTF-8") as html:
                     html_contents = html.read()
+
                 with figure(style="float: right"):
-                    with section(id=str('M'+str(i))):
+                    with section(id=f"M{i}"):
                         raw(html_contents)
-                        if f[1] in tables:
-                            raw(tables[f[1]])
+
+                        # Insert associated table (unchanged)
+                        if title in tables:
+                            raw(tables[title])

--- a/main.nf
+++ b/main.nf
@@ -42,20 +42,20 @@ process getParams {
 process makeReport {
     label "wfqc"
     input:
-        val plots_html
+        path plots_dir
         path "QC-repport/report.data"
         path "versions/*"
         path "params.json"
     output:
         path "wf-template-*.html"
     script:
-        String report_name = "wf-template-report.html"
+        String report_name = "wf-toulligqc-report.html"
     """
     workflow-glue report $report_name \
         --versions versions \
         --params params.json \
         --metadata QC-repport/report.data \
-        --qc ${plots_html.join()}
+        --qc ${plots_dir}
     """
 }
 
@@ -77,6 +77,7 @@ process toulligqc {
         path "$report_name/report.data", emit: report_data
         path "$report_name/images/*.html", emit: plots_html
         path "$report_name/images/plotly.min.js", emit: plotly_js
+        path "$report_name/images", emit: plots_dir
     script:
         def seq_summary_arg = seq_summary.name != 'no_seq_summary' ? "--sequencing-summary-source $seq_summary" : ""
         def summary_pass_arg = summary_pass.name != 'no_barcoding_pass' ? "--sequencing-summary-source $summary_pass" : ""
@@ -134,10 +135,10 @@ workflow pipeline {
 
         plotly_js = toulligqc.out.plotly_js
 
-        plots_html = toulligqc.out.plots_html.toList()
+        plots_dir = toulligqc.out.plots_dir
 
         report = makeReport(
-            plots_html, toulligqc.out.report_data, software_versions.collect(), workflow_params
+            plots_dir, toulligqc.out.report_data, software_versions.collect(), workflow_params
         )
     emit:
         plotly_js

--- a/main.nf
+++ b/main.nf
@@ -47,7 +47,7 @@ process makeReport {
         path "versions/*"
         path "params.json"
     output:
-        path "wf-template-*.html"
+        path "wf-toulligqc-*.html"
     script:
         String report_name = "wf-toulligqc-report.html"
     """


### PR DESCRIPTION
The input of the html files into the makeReport process was done via list "val plots_html".
As a result Nextflow does not stage the files into the makeReport process. As a result the file paths point to the previous task's sandbox which Nextflow isolates and therefore, these are not visible inside the container. This causes a FileNotFound error on slurm HPC.

Fix:

* declared output of toulligqc process to: path "${report_name}/images", emit: plots_dir
* declared the input of the makeReport process to: path plots_dir
* changed the add_qc function in filter_metadata.py accordingly
* renamed report wf-template-*.html -> wf-toulligqc-*.html 